### PR TITLE
Feat/json ignore unknown properties

### DIFF
--- a/src/main/java/io/github/sashirestela/cleverclient/util/JsonUtil.java
+++ b/src/main/java/io/github/sashirestela/cleverclient/util/JsonUtil.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
@@ -11,7 +12,8 @@ import com.fasterxml.jackson.databind.type.CollectionType;
 import io.github.sashirestela.cleverclient.support.CleverClientException;
 
 public class JsonUtil {
-    private static ObjectMapper objectMapper = new ObjectMapper();
+    private static ObjectMapper objectMapper = new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     private JsonUtil() {
     }

--- a/src/main/java/io/github/sashirestela/cleverclient/util/JsonUtil.java
+++ b/src/main/java/io/github/sashirestela/cleverclient/util/JsonUtil.java
@@ -1,5 +1,6 @@
 package io.github.sashirestela.cleverclient.util;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -7,20 +8,22 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.type.CollectionType;
 
 import io.github.sashirestela.cleverclient.support.CleverClientException;
 
 public class JsonUtil {
-    private static ObjectMapper objectMapper = new ObjectMapper()
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private static final ObjectMapper objectMapperStrict = new ObjectMapper();
+    private static final ObjectReader objectReaderIgnoringUnknown = objectMapperStrict.reader()
+            .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
     private JsonUtil() {
     }
 
     public static <T> String objectToJson(T object) {
         try {
-            return objectMapper.writeValueAsString(object);
+            return objectMapperStrict.writeValueAsString(object);
         } catch (JsonProcessingException e) {
             throw new CleverClientException("Cannot convert the object {0} to Json.", object, e);
         }
@@ -28,16 +31,24 @@ public class JsonUtil {
 
     public static <T> T jsonToObject(String json, Class<T> clazz) {
         try {
-            return objectMapper.readValue(json, clazz);
-        } catch (JsonProcessingException e) {
+            return objectReaderIgnoringUnknown.readValue(json, clazz);
+        } catch (IOException e) {
+            throw new CleverClientException("Cannot convert the Json {0} to class {1}.", json, clazz.getName(), e);
+        }
+    }
+
+    public static <T> T jsonToObjectStrict(String json, Class<T> clazz) {
+        try {
+            return objectMapperStrict.readValue(json, clazz);
+        } catch (IOException e) {
             throw new CleverClientException("Cannot convert the Json {0} to class {1}.", json, clazz.getName(), e);
         }
     }
 
     public static <T> List<T> jsonToList(String json, Class<T> clazz) {
         try {
-            CollectionType listType = objectMapper.getTypeFactory().constructCollectionType(ArrayList.class, clazz);
-            return objectMapper.readValue(json, listType);
+            CollectionType listType = objectReaderIgnoringUnknown.getTypeFactory().constructCollectionType(ArrayList.class, clazz);
+            return objectReaderIgnoringUnknown.forType(listType).readValue(json);
         } catch (JsonProcessingException e) {
             throw new CleverClientException("Cannot convert the Json {0} to List of {1}.", json, clazz.getName(), e);
         }
@@ -45,8 +56,8 @@ public class JsonUtil {
 
     public static <T, U> T jsonToParametricObject(String json, Class<T> clazzT, Class<U> clazzU) {
         try {
-            JavaType javaType = objectMapper.getTypeFactory().constructParametricType(clazzT, clazzU);
-            return objectMapper.readValue(json, javaType);
+            JavaType javaType = objectReaderIgnoringUnknown.getTypeFactory().constructParametricType(clazzT, clazzU);
+            return objectReaderIgnoringUnknown.forType(javaType).readValue(json);
         } catch (JsonProcessingException e) {
             throw new CleverClientException("Cannot convert the Json {0} to class of {1}.", json, clazzT.getName(), e);
         }

--- a/src/test/java/io/github/sashirestela/cleverclient/util/JsonUtilTest.java
+++ b/src/test/java/io/github/sashirestela/cleverclient/util/JsonUtilTest.java
@@ -42,8 +42,17 @@ class JsonUtilTest {
 
     @Test
     void shouldThrowExceptionWhenConvertingJsonToObjectWithIssues() {
-        String json = "{\"first\":\"test\",\"secondish\":10}";
+        String json = "{\"first\":\"test\",\"second\":\"WRONG TYPE\"}";
         assertThrows(CleverClientException.class, () -> JsonUtil.jsonToObject(json, TestClass.class));
+    }
+
+    @Test
+    void shouldGracefullyIgnoreUnknownPropertiesWhenConvertingJsonToObject() {
+        String json = "{\"first\":\"test\",\"unknown_property\":1}";
+        TestClass actualObject = JsonUtil.jsonToObject(json, TestClass.class);
+        TestClass expectedObject = new TestClass("test", null);
+        assertEquals(expectedObject.getFirst(), actualObject.getFirst());
+        assertEquals(expectedObject.getSecond(), actualObject.getSecond());
     }
 
     @Test
@@ -62,7 +71,7 @@ class JsonUtilTest {
 
     @Test
     void shouldThrowExceptionWhenConvertingJsonToListWithIssues() {
-        String json = "[{\"first\":\"test1\",\"second\":10},{\"firstish\":\"test2\",\"secondish\":20}]";
+        String json = "[{\"first\":\"test1\",\"second\":10},{\"first\":[\"WRONG TYPE\"],\"second\":\"WRONG TYPE\"}]";
         assertThrows(CleverClientException.class, () -> JsonUtil.jsonToList(json, TestClass.class));
     }
 
@@ -90,7 +99,7 @@ class JsonUtilTest {
     @Test
     void shouldThrowExceptionWhenConvertingJsonToParametricObjectWithIssues() {
         String json = "{\"id\":\"abc\",\"data\":[{\"first\":\"test1\",\"second\":10}," +
-                "{\"firstish\":\"test2\",\"secondish\":20}]}";
+                "{\"first\":\"test2\",\"second\":\"WRONG TYPE\"}]}";
         assertThrows(CleverClientException.class,
                 () -> JsonUtil.jsonToParametricObject(json, TestGeneric.class, TestClass.class));
     }


### PR DESCRIPTION
The client side of any API should ignore any unknown properties send by the server side of the API.

This is important for two reasons:
1. Client side is more "resistant" to the possible (non-breaking) changes to the API from the server side.
2. When trying to extend API to work with Azure I stumbled across the problem that Azure, although has similar endpoints to the OpenAI ones, but sometimes returns a lot more fields in the response, fields that aren't available in OpenAI API, and fields which we usually don't need. Without this proposed modification, I'm unable to easily extend the client to work with Azure endpoints.