### PR TITLE
urlBase -> baseUrl + make some fields final

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ public interface PostService {
 
 // Use CleverClient to call the API
 var cleverClient = CleverClient.builder()
-    .urlBase("https://jsonplaceholder.typicode.com/")
+    .baseUrl("https://jsonplaceholder.typicode.com/")
     .build();
 
 var postService = cleverClient.create(PostService.class);
@@ -97,7 +97,7 @@ We have the following attributes to create a CleverClient object:
 
 | Attribute   | Description                            | Required  |
 | ----------- |----------------------------------------|-----------|
-| urlBase     | Api's url                              | mandatory |
+| baseUrl     | Api's url                              | mandatory |
 | headers     | Pairs of headers name/value            | optional  |
 | httpClient  | Java HttpClient object                 | optional  |
 | endOfStream | Text used to mark the final of streams | optional  |
@@ -107,7 +107,7 @@ The attribute ```endOfStream``` is required when you have endpoints sending back
 Example:
 
 ```java
-final var URL_BASE = "https://api.example.com";
+final var BASE_URL = "https://api.example.com";
 final var HEADER_NAME = "Authorization";
 final var HEADER_VALUE = "Bearer qwertyasdfghzxcvb";
 final var END_OF_STREAM = "[DONE]";
@@ -121,7 +121,7 @@ var httpClient = HttpClient.newBuilder()
     .build();
 
 var cleverClient = CleverClient.builder()
-    .urlBase(URL_BASE)
+    .baseUrl(BASE_URL)
     .headers(Arrays.asList(HEADER_NAME, HEADER_VALUE))
     .httpClient(httpClient)
     .endOfStream(END_OF_STREAM)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.sashirestela</groupId>
   <artifactId>cleverclient</artifactId>
-  <version>0.12.0</version>
+  <version>0.13.0</version>
   <packaging>jar</packaging>
 
   <name>cleverclient</name>

--- a/src/example/java/io/github/sashirestela/cleverclient/example/BasicExample.java
+++ b/src/example/java/io/github/sashirestela/cleverclient/example/BasicExample.java
@@ -7,10 +7,10 @@ import io.github.sashirestela.cleverclient.example.jsonplaceholder.PostService;
 public class BasicExample {
 
     public static void main(String[] args) {
-        final var URL_BASE = "https://jsonplaceholder.typicode.com";
+        final var BASE_URL = "https://jsonplaceholder.typicode.com";
 
         var cleverClient = CleverClient.builder()
-                .urlBase(URL_BASE)
+                .baseUrl(BASE_URL)
                 .build();
         var postService = cleverClient.create(PostService.class);
 

--- a/src/example/java/io/github/sashirestela/cleverclient/example/FileDownloadExample.java
+++ b/src/example/java/io/github/sashirestela/cleverclient/example/FileDownloadExample.java
@@ -17,10 +17,10 @@ public class FileDownloadExample {
     }
 
     public static void main(String[] args) throws IOException {
-        final var URL_BASE = "https://via.placeholder.com";
+        final var BASE_URL = "https://via.placeholder.com";
 
         var cleverClient = CleverClient.builder()
-                .urlBase(URL_BASE)
+                .baseUrl(BASE_URL)
                 .build();
 
         var imageService = cleverClient.create(ImageService.class);

--- a/src/example/java/io/github/sashirestela/cleverclient/example/HeaderExample.java
+++ b/src/example/java/io/github/sashirestela/cleverclient/example/HeaderExample.java
@@ -27,10 +27,10 @@ public class HeaderExample {
     }
 
     public static void main(String[] args) {
-        final var URL_BASE = "https://httpbin.org";
+        final var BASE_URL = "https://httpbin.org";
 
         var cleverClient = CleverClient.builder()
-                .urlBase(URL_BASE)
+                .baseUrl(BASE_URL)
                 .build();
 
         var classHeaderService = cleverClient.create(ClassHeaderService.class);

--- a/src/example/java/io/github/sashirestela/cleverclient/example/MultiServiceExample.java
+++ b/src/example/java/io/github/sashirestela/cleverclient/example/MultiServiceExample.java
@@ -7,10 +7,10 @@ import io.github.sashirestela.cleverclient.example.jsonplaceholder.PostService;
 public class MultiServiceExample {
 
     public static void main(String[] args) {
-        final var URL_BASE = "https://jsonplaceholder.typicode.com";
+        final var BASE_URL = "https://jsonplaceholder.typicode.com";
 
         var cleverClient = CleverClient.builder()
-                .urlBase(URL_BASE)
+                .baseUrl(BASE_URL)
                 .build();
         var postService = cleverClient.create(PostService.class);
         var albumService = cleverClient.create(AlbumService.class);

--- a/src/example/java/io/github/sashirestela/cleverclient/example/StreamExample.java
+++ b/src/example/java/io/github/sashirestela/cleverclient/example/StreamExample.java
@@ -17,13 +17,13 @@ import io.github.sashirestela.cleverclient.example.openai.Message;
 public class StreamExample {
 
     public static void main(String[] args) {
-        final var URL_BASE = "https://api.openai.com";
+        final var BASE_URL = "https://api.openai.com";
         final var AUTHORIZATION_HEADER = "Authorization";
         final var BEARER_AUTHORIZATION = "Bearer " + System.getenv("OPENAI_API_KEY");
         final var END_OF_STREAM = "[DONE]";
 
         var cleverClient = CleverClient.builder()
-                .urlBase(URL_BASE)
+                .baseUrl(BASE_URL)
                 .headers(Arrays.asList(AUTHORIZATION_HEADER, BEARER_AUTHORIZATION))
                 .endOfStream(END_OF_STREAM)
                 .build();

--- a/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
+++ b/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
@@ -56,7 +56,7 @@ public class CleverClient {
         if (isNullOrEmpty(baseUrl)  && isNullOrEmpty(urlBase)) {
             throw new CleverClientException("At least one of baseUrl and urlBase is mandatory.", null, null);
         }
-        if (isNullOrEmpty( baseUrl)) {
+        if (!isNullOrEmpty(baseUrl)) {
             this.baseUrl = baseUrl;
         } else {
             this.baseUrl = urlBase;

--- a/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
+++ b/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
@@ -1,5 +1,7 @@
 package io.github.sashirestela.cleverclient;
 
+import static io.github.sashirestela.cleverclient.util.CommonUtil.isNullOrEmpty;
+
 import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Optional;
@@ -26,7 +28,7 @@ public class CleverClient {
 
     private final String baseUrl;
     @Deprecated
-    private final String urlBase = ""; // never need to use this deprecated
+    private final String urlBase = null;
     private final List<String> headers;
     private final HttpClient httpClient;
     private final HttpProcessor httpProcessor;
@@ -39,6 +41,8 @@ public class CleverClient {
      *                    in case both are specified and different baseUrl takes precedence
      *
      * @param urlBase     [[ Deprecated ]] Root of the url of the API service to call.
+     *                    it is here for backward compatibility only. It will be removed in
+     *                    a future version. use `baseUrl()` instead.
      * @param headers     Http headers for all the API service. Header's name and
      *                    value must be individual entries in the list. Optional.
      * @param httpClient  Custom Java's HttpClient component. One is created by
@@ -49,7 +53,7 @@ public class CleverClient {
     @Builder
     public CleverClient(String baseUrl, String urlBase, @Singular List<String> headers, HttpClient httpClient,
             String endOfStream) {
-        if ((baseUrl == null || baseUrl.isEmpty()) && (urlBase == null || urlBase.isEmpty())) {
+        if (isNullOrEmpty(baseUrl)  && isNullOrEmpty(urlBase)) {
             throw new CleverClientException("At least one of baseUrl and urlBase is mandatory.", null, null);
         }
         if (baseUrl != null && !baseUrl.isEmpty()) {

--- a/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
+++ b/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
@@ -25,6 +25,8 @@ public class CleverClient {
     private static final Logger logger = LoggerFactory.getLogger(CleverClient.class);
 
     private final String baseUrl;
+    @Deprecated
+    private final String urlBase = ""; // never need to use this deprecated
     private final List<String> headers;
     private final HttpClient httpClient;
     private final HttpProcessor httpProcessor;
@@ -32,7 +34,11 @@ public class CleverClient {
     /**
      * Constructor to create an instance of CleverClient.
      * 
-     * @param baseUrl     Root of the url of the API service to call. Mandatory.
+     * @param baseUrl     Root of the url of the API service to call.
+     *                    at least one of baseUrl and the deprecated urlBase is mandatory.
+     *                    in case both are specified and different baseUrl takes precedence
+     *
+     * @param urlBase     [[ Deprecated ]] Root of the url of the API service to call.
      * @param headers     Http headers for all the API service. Header's name and
      *                    value must be individual entries in the list. Optional.
      * @param httpClient  Custom Java's HttpClient component. One is created by
@@ -41,9 +47,16 @@ public class CleverClient {
      *                    server sent events (SSE). Optional.
      */
     @Builder
-    public CleverClient(@NonNull String baseUrl, @Singular List<String> headers, HttpClient httpClient,
+    public CleverClient(String baseUrl, String urlBase, @Singular List<String> headers, HttpClient httpClient,
             String endOfStream) {
-        this.baseUrl = baseUrl;
+        if ((baseUrl == null || baseUrl.isEmpty()) && (urlBase == null || urlBase.isEmpty())) {
+            throw new CleverClientException("At least one of baseUrl and urlBase is mandatory.", null, null);
+        }
+        if (baseUrl != null && !baseUrl.isEmpty()) {
+            this.baseUrl = baseUrl;
+        } else {
+            this.baseUrl = urlBase;
+        }
         this.headers = Optional.ofNullable(headers).orElse(List.of());
         if (this.headers.size() % 2 > 0) {
             throw new CleverClientException("Headers must be entered as pair of values in the list.", null, null);

--- a/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
+++ b/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
@@ -56,11 +56,7 @@ public class CleverClient {
         if (isNullOrEmpty(baseUrl)  && isNullOrEmpty(urlBase)) {
             throw new CleverClientException("At least one of baseUrl and urlBase is mandatory.", null, null);
         }
-        if (!isNullOrEmpty(baseUrl)) {
-            this.baseUrl = baseUrl;
-        } else {
-            this.baseUrl = urlBase;
-        }
+        this.baseUrl = isNullOrEmpty(baseUrl) ? urlBase : baseUrl;
         this.headers = Optional.ofNullable(headers).orElse(List.of());
         if (this.headers.size() % 2 > 0) {
             throw new CleverClientException("Headers must be entered as pair of values in the list.", null, null);

--- a/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
+++ b/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
@@ -14,7 +14,6 @@ import io.github.sashirestela.cleverclient.support.CleverClientException;
 import io.github.sashirestela.cleverclient.support.CleverClientSSE;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Singular;
 
 /**

--- a/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
+++ b/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
@@ -22,17 +22,17 @@ import lombok.Singular;
  */
 @Getter
 public class CleverClient {
-    private static Logger logger = LoggerFactory.getLogger(CleverClient.class);
+    private static final Logger logger = LoggerFactory.getLogger(CleverClient.class);
 
-    private String urlBase;
-    private List<String> headers;
-    private HttpClient httpClient;
-    private HttpProcessor httpProcessor;
+    private final String baseUrl;
+    private final List<String> headers;
+    private final HttpClient httpClient;
+    private final HttpProcessor httpProcessor;
 
     /**
      * Constructor to create an instance of CleverClient.
      * 
-     * @param urlBase     Root of the url of the API service to call. Mandatory.
+     * @param baseUrl     Root of the url of the API service to call. Mandatory.
      * @param headers     Http headers for all the API service. Header's name and
      *                    value must be individual entries in the list. Optional.
      * @param httpClient  Custom Java's HttpClient component. One is created by
@@ -41,16 +41,16 @@ public class CleverClient {
      *                    server sent events (SSE). Optional.
      */
     @Builder
-    public CleverClient(@NonNull String urlBase, @Singular List<String> headers, HttpClient httpClient,
+    public CleverClient(@NonNull String baseUrl, @Singular List<String> headers, HttpClient httpClient,
             String endOfStream) {
-        this.urlBase = urlBase;
+        this.baseUrl = baseUrl;
         this.headers = Optional.ofNullable(headers).orElse(List.of());
         if (this.headers.size() % 2 > 0) {
             throw new CleverClientException("Headers must be entered as pair of values in the list.", null, null);
         }
         this.httpClient = Optional.ofNullable(httpClient).orElse(HttpClient.newHttpClient());
         CleverClientSSE.setEndOfStream(endOfStream);
-        this.httpProcessor = new HttpProcessor(this.urlBase, this.headers, this.httpClient);
+        this.httpProcessor = new HttpProcessor(this.baseUrl, this.headers, this.httpClient);
         logger.debug("CleverClient has been created.");
     }
 

--- a/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
+++ b/src/main/java/io/github/sashirestela/cleverclient/CleverClient.java
@@ -56,7 +56,7 @@ public class CleverClient {
         if (isNullOrEmpty(baseUrl)  && isNullOrEmpty(urlBase)) {
             throw new CleverClientException("At least one of baseUrl and urlBase is mandatory.", null, null);
         }
-        if (baseUrl != null && !baseUrl.isEmpty()) {
+        if (isNullOrEmpty( baseUrl)) {
             this.baseUrl = baseUrl;
         } else {
             this.baseUrl = urlBase;

--- a/src/main/java/io/github/sashirestela/cleverclient/http/HttpProcessor.java
+++ b/src/main/java/io/github/sashirestela/cleverclient/http/HttpProcessor.java
@@ -22,19 +22,19 @@ import io.github.sashirestela.cleverclient.util.ReflectUtil;
 public class HttpProcessor implements InvocationHandler {
     private static final Logger logger = LoggerFactory.getLogger(HttpProcessor.class);
 
-    private HttpClient httpClient;
-    private String urlBase;
-    private List<String> headers;
+    private final HttpClient httpClient;
+    private final String baseUrl;
+    private final List<String> headers;
 
     /**
      * Constructor to create an instance of HttpProcessor.
      * 
      * @param httpClient Java's HttpClient component that solves the http calling.
-     * @param urlBase    Root of the url of the API service to call.
+     * @param baseUrl    Root of the url of the API service to call.
      * @param headers    Http headers for all the API service.
      */
-    public HttpProcessor(String urlBase, List<String> headers, HttpClient httpClient) {
-        this.urlBase = urlBase;
+    public HttpProcessor(String baseUrl, List<String> headers, HttpClient httpClient) {
+        this.baseUrl = baseUrl;
         this.headers = headers;
         this.httpClient = httpClient;
     }
@@ -93,7 +93,7 @@ public class HttpProcessor implements InvocationHandler {
     /**
      * Reads the interface method metadata from memory and uses them to prepare an
      * HttpConnector object that will resend the request to the Java's HttpClient
-     * and will receive the response. This method is called from the invoke mehod.
+     * and will receive the response. This method is called from the invoke method.
      * 
      * @param method    The Method instance corresponding to the interface method
      *                  invoked on the proxy instance.
@@ -106,7 +106,7 @@ public class HttpProcessor implements InvocationHandler {
         var interfaceMetadata = InterfaceMetadataStore.one().get(method.getDeclaringClass());
         var methodMetadata = interfaceMetadata.getMethodBySignature().get(method.toString());
         var urlMethod = interfaceMetadata.getFullUrlByMethod(methodMetadata);
-        var url = urlBase + URLBuilder.one().build(urlMethod, methodMetadata, arguments);
+        var url = baseUrl + URLBuilder.one().build(urlMethod, methodMetadata, arguments);
         var httpMethod = methodMetadata.getHttpAnnotationName();
         var returnType = methodMetadata.getReturnType();
         var isMultipart = methodMetadata.isMultipart();

--- a/src/main/java/io/github/sashirestela/cleverclient/metadata/InterfaceMetadataStore.java
+++ b/src/main/java/io/github/sashirestela/cleverclient/metadata/InterfaceMetadataStore.java
@@ -68,7 +68,7 @@ public class InterfaceMetadataStore {
         if (interfacesByFullName.containsKey(interfaceClass.getName())) {
             return interfacesByFullName.get(interfaceClass.getName());
         } else {
-            throw new CleverClientException("The interaface {0} has not been saved yet.", interfaceClass.getSimpleName(),
+            throw new CleverClientException("The interface {0} has not been saved yet.", interfaceClass.getSimpleName(),
                     null);
         }
     }
@@ -125,7 +125,7 @@ public class InterfaceMetadataStore {
         interfaceMetadata.getMethodBySignature().forEach((methodSignature, methodMetadata) -> {
             if (!methodMetadata.isDefault()) {
                 if (!methodMetadata.hasHttpAnnotation()) {
-                    throw new CleverClientException("Missing HTTP anotation for the method {0}.",
+                    throw new CleverClientException("Missing HTTP annotation for the method {0}.",
                             methodMetadata.getName(), null);
                 }
             }

--- a/src/test/java/io/github/sashirestela/cleverclient/CleverClientTest.java
+++ b/src/test/java/io/github/sashirestela/cleverclient/CleverClientTest.java
@@ -41,14 +41,14 @@ class CleverClientTest {
     }
 
     @Test
-    void shouldThrownExceptionWhenTryingToPassAnEmptyUrlBase() {
+    void shouldThrownExceptionWhenTryingToPassAnEmptyBaseUrl() {
         var cleverClientBuilder = CleverClient.builder()
                 .header("headerName")
                 .header("headerValue")
                 .httpClient(HttpClient.newHttpClient())
                 .endOfStream("[DONE]");
         assertThrows(NullPointerException.class,
-                () -> cleverClientBuilder.build());
+            cleverClientBuilder::build);
     }
 
     @Test
@@ -57,8 +57,9 @@ class CleverClientTest {
                 .baseUrl("http://test")
                 .header("oneHeader");
         Exception exception = assertThrows(CleverClientException.class,
-                () -> cleverClientBuilder.build());
-        assertTrue(exception.getMessage().equals("Headers must be entered as pair of values in the list."));
+            cleverClientBuilder::build);
+        assertEquals("Headers must be entered as pair of values in the list.",
+          exception.getMessage());
     }
 
     interface TestCleverClient {

--- a/src/test/java/io/github/sashirestela/cleverclient/CleverClientTest.java
+++ b/src/test/java/io/github/sashirestela/cleverclient/CleverClientTest.java
@@ -19,18 +19,18 @@ class CleverClientTest {
     @Test
     void shouldSetPropertiesToDefaultValuesWhenBuilderIsCalledWithoutThoseProperties() {
         var cleverClient = CleverClient.builder()
-                .urlBase("https://test")
+                .baseUrl("https://test")
                 .build();
         assertEquals(List.of(), cleverClient.getHeaders());
         assertEquals(HttpClient.Version.HTTP_2, cleverClient.getHttpClient().version());
-        assertNotNull(cleverClient.getUrlBase());
+        assertNotNull(cleverClient.getBaseUrl());
         assertNotNull(cleverClient.getHttpProcessor());
     }
 
     @Test
     void shouldImplementInterfaceWhenCallingCreate() {
         var cleverClient = CleverClient.builder()
-                .urlBase("https://test")
+                .baseUrl("https://test")
                 .header("headerName")
                 .header("headerValue")
                 .httpClient(HttpClient.newHttpClient())
@@ -54,7 +54,7 @@ class CleverClientTest {
     @Test
     void shouldThrownExceptionWhenTryingToPassAnOddNumbersOfHeaders() {
         var cleverClientBuilder = CleverClient.builder()
-                .urlBase("http://test")
+                .baseUrl("http://test")
                 .header("oneHeader");
         Exception exception = assertThrows(CleverClientException.class,
                 () -> cleverClientBuilder.build());

--- a/src/test/java/io/github/sashirestela/cleverclient/CleverClientTest.java
+++ b/src/test/java/io/github/sashirestela/cleverclient/CleverClientTest.java
@@ -3,7 +3,6 @@ package io.github.sashirestela.cleverclient;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.http.HttpClient;
 import java.util.List;

--- a/src/test/java/io/github/sashirestela/cleverclient/CleverClientTest.java
+++ b/src/test/java/io/github/sashirestela/cleverclient/CleverClientTest.java
@@ -16,67 +16,69 @@ import io.github.sashirestela.cleverclient.support.CleverClientException;
 
 class CleverClientTest {
 
-    @Test
-    void shouldSetPropertiesToDefaultValuesWhenBuilderIsCalledWithoutThoseProperties() {
-        var cleverClient = CleverClient.builder()
-                .baseUrl("https://test")
-                .build();
-        assertEquals(List.of(), cleverClient.getHeaders());
-        assertEquals(HttpClient.Version.HTTP_2, cleverClient.getHttpClient().version());
-        assertNotNull(cleverClient.getBaseUrl());
-        assertNotNull(cleverClient.getHttpProcessor());
-    }
 
-    @Test
-    void shouldSetPropertiesToDefaultValuesWhenBuilderIsCalledWithoutThoseProperties2() {
-        var baseUrl = "https://test";
-        var cleverClient = CleverClient.builder()
-            .urlBase(baseUrl)
-            .build();
-        assertEquals(List.of(), cleverClient.getHeaders());
-        assertEquals(HttpClient.Version.HTTP_2, cleverClient.getHttpClient().version());
-        // verify that baseUrl is set when building with the deprecated urlBase() method
-        assertEquals(cleverClient.getBaseUrl(), baseUrl);
-        assertNotNull(cleverClient.getHttpProcessor());
-    }
+  @Test
+  void shouldSetPropertiesToDefaultValuesWhenBuilderIsCalledWithoutThoseProperties() {
+    var cleverClient = CleverClient.builder()
+        .baseUrl("https://test")
+        .build();
+    assertEquals(List.of(), cleverClient.getHeaders());
+    assertEquals(HttpClient.Version.HTTP_2, cleverClient.getHttpClient().version());
+    assertNotNull(cleverClient.getBaseUrl());
+    assertNotNull(cleverClient.getHttpProcessor());
+  }
 
-    @Test
-    void shouldImplementInterfaceWhenCallingCreate() {
-        var cleverClient = CleverClient.builder()
-                .baseUrl("https://test")
-                .header("headerName")
-                .header("headerValue")
-                .httpClient(HttpClient.newHttpClient())
-                .endOfStream("[DONE]")
-                .build();
-        var test = cleverClient.create(TestCleverClient.class);
-        assertNotNull(test);
-    }
+  @Test
+  void shouldBuildSuccessfullyUsingDeprecatedUrlBase() {
+    var baseUrl = "https://test";
+    var cleverClient = CleverClient.builder()
+        .urlBase(baseUrl)
+        .build();
+    assertEquals(List.of(), cleverClient.getHeaders());
+    assertEquals(HttpClient.Version.HTTP_2, cleverClient.getHttpClient().version());
+    // verify that baseUrl is set when building with the deprecated urlBase() method
+    assertEquals(cleverClient.getBaseUrl(), baseUrl);
+    assertNotNull(cleverClient.getHttpProcessor());
+  }
 
-    @Test
-    void shouldThrownExceptionWhenTryingToPassAnEmptyBaseUrl() {
-        var cleverClientBuilder = CleverClient.builder()
-                .header("headerName")
-                .header("headerValue")
-                .httpClient(HttpClient.newHttpClient())
-                .endOfStream("[DONE]");
-        assertThrows(CleverClientException.class,
-            cleverClientBuilder::build);
-    }
+  @Test
+  void shouldImplementInterfaceWhenCallingCreate() {
+    var cleverClient = CleverClient.builder()
+        .baseUrl("https://test")
+        .header("headerName")
+        .header("headerValue")
+        .httpClient(HttpClient.newHttpClient())
+        .endOfStream("[DONE]")
+        .build();
+    var test = cleverClient.create(TestCleverClient.class);
+    assertNotNull(test);
+  }
 
-    @Test
-    void shouldThrownExceptionWhenTryingToPassAnOddNumbersOfHeaders() {
-        var cleverClientBuilder = CleverClient.builder()
-                .baseUrl("http://test")
-                .header("oneHeader");
-        Exception exception = assertThrows(CleverClientException.class,
-            cleverClientBuilder::build);
-        assertEquals("Headers must be entered as pair of values in the list.",
-          exception.getMessage());
-    }
+  @Test
+  void shouldThrownExceptionWhenTryingToPassAnEmptyBaseUrlAndUrlBase() {
+    var cleverClientBuilder = CleverClient.builder()
+        .header("headerName")
+        .header("headerValue")
+        .httpClient(HttpClient.newHttpClient())
+        .endOfStream("[DONE]");
+    assertThrows(CleverClientException.class,
+        cleverClientBuilder::build);
+  }
 
-    interface TestCleverClient {
-        @GET("/api/")
-        CompletableFuture<String> getText();
-    }
+  @Test
+  void shouldThrownExceptionWhenTryingToPassAnOddNumbersOfHeaders() {
+    var cleverClientBuilder = CleverClient.builder()
+        .baseUrl("http://test")
+        .header("oneHeader");
+    Exception exception = assertThrows(CleverClientException.class,
+        cleverClientBuilder::build);
+    assertEquals("Headers must be entered as pair of values in the list.",
+        exception.getMessage());
+  }
+
+  interface TestCleverClient {
+
+    @GET("/api/")
+    CompletableFuture<String> getText();
+  }
 }

--- a/src/test/java/io/github/sashirestela/cleverclient/CleverClientTest.java
+++ b/src/test/java/io/github/sashirestela/cleverclient/CleverClientTest.java
@@ -28,6 +28,19 @@ class CleverClientTest {
     }
 
     @Test
+    void shouldSetPropertiesToDefaultValuesWhenBuilderIsCalledWithoutThoseProperties2() {
+        var baseUrl = "https://test";
+        var cleverClient = CleverClient.builder()
+            .urlBase(baseUrl)
+            .build();
+        assertEquals(List.of(), cleverClient.getHeaders());
+        assertEquals(HttpClient.Version.HTTP_2, cleverClient.getHttpClient().version());
+        // verify that baseUrl is set when building with the deprecated urlBase() method
+        assertEquals(cleverClient.getBaseUrl(), baseUrl);
+        assertNotNull(cleverClient.getHttpProcessor());
+    }
+
+    @Test
     void shouldImplementInterfaceWhenCallingCreate() {
         var cleverClient = CleverClient.builder()
                 .baseUrl("https://test")

--- a/src/test/java/io/github/sashirestela/cleverclient/CleverClientTest.java
+++ b/src/test/java/io/github/sashirestela/cleverclient/CleverClientTest.java
@@ -60,7 +60,7 @@ class CleverClientTest {
                 .header("headerValue")
                 .httpClient(HttpClient.newHttpClient())
                 .endOfStream("[DONE]");
-        assertThrows(NullPointerException.class,
+        assertThrows(CleverClientException.class,
             cleverClientBuilder::build);
     }
 

--- a/src/test/java/io/github/sashirestela/cleverclient/http/ITest.java
+++ b/src/test/java/io/github/sashirestela/cleverclient/http/ITest.java
@@ -114,6 +114,13 @@ public interface ITest {
         Stream<Demo> getDemoStream(@Body RequestDemo request);
     }
 
+    interface NotSavedService {
+
+        @GET("/demos")
+        CompletableFuture<List<Demo>> goodMethod();
+
+    }
+
     @NoArgsConstructor
     @AllArgsConstructor
     @Getter

--- a/src/test/java/io/github/sashirestela/cleverclient/metadata/InterfaceMetadataStoreTest.java
+++ b/src/test/java/io/github/sashirestela/cleverclient/metadata/InterfaceMetadataStoreTest.java
@@ -135,16 +135,15 @@ public class InterfaceMetadataStoreTest {
     void shouldThrownExceptionWhenTryingToGetNotPreviouslySavedInterface() {
         Exception exception = assertThrows(CleverClientException.class,
                 () -> store.get(ITest.SyncService.class));
-        assertTrue(exception.getMessage().equals(
-                "The interaface SyncService has not been saved yet."));
+      assertEquals("The interface SyncService has not been saved yet.", exception.getMessage());
     }
 
     @Test
     void shouldThrownExceptionWhenMethodHasNotHttpAnnotation() {
         Exception exception = assertThrows(CleverClientException.class,
                 () -> store.save(ITest.NotAnnotatedService.class));
-        assertTrue(exception.getMessage().equals(
-                "Missing HTTP anotation for the method unannotatedMethod."));
+      assertEquals("Missing HTTP annotation for the method unannotatedMethod.",
+          exception.getMessage());
     }
 
     @Test

--- a/src/test/java/io/github/sashirestela/cleverclient/metadata/InterfaceMetadataStoreTest.java
+++ b/src/test/java/io/github/sashirestela/cleverclient/metadata/InterfaceMetadataStoreTest.java
@@ -150,7 +150,7 @@ public class InterfaceMetadataStoreTest {
     void shouldThrownExceptionWhenUrlPathParamAtMethodUnmatchesAnnotatedArguments() {
         Exception exception = assertThrows(CleverClientException.class,
                 () -> store.save(ITest.BadPathParamService.class));
-        assertTrue(exception.getMessage().equals(
-                "Path param demoId in the url cannot find an annotated argument in the method unmatchedPathParamMethod."));
+        assertEquals(exception.getMessage(),
+                "Path param demoId in the url cannot find an annotated argument in the method unmatchedPathParamMethod.");
     }
 }

--- a/src/test/java/io/github/sashirestela/cleverclient/metadata/InterfaceMetadataStoreTest.java
+++ b/src/test/java/io/github/sashirestela/cleverclient/metadata/InterfaceMetadataStoreTest.java
@@ -134,8 +134,8 @@ public class InterfaceMetadataStoreTest {
     @Test
     void shouldThrownExceptionWhenTryingToGetNotPreviouslySavedInterface() {
         Exception exception = assertThrows(CleverClientException.class,
-                () -> store.get(ITest.SyncService.class));
-      assertEquals("The interface SyncService has not been saved yet.", exception.getMessage());
+                () -> store.get(ITest.NotSavedService.class));
+      assertEquals("The interface NotSavedService has not been saved yet.", exception.getMessage());
     }
 
     @Test
@@ -149,8 +149,8 @@ public class InterfaceMetadataStoreTest {
     @Test
     void shouldThrownExceptionWhenUrlPathParamAtMethodUnmatchesAnnotatedArguments() {
         Exception exception = assertThrows(CleverClientException.class,
-                () -> store.save(ITest.BadPathParamService.class));
-        assertEquals(exception.getMessage(),
-                "Path param demoId in the url cannot find an annotated argument in the method unmatchedPathParamMethod.");
+            () -> store.save(ITest.BadPathParamService.class));
+        assertEquals("Path param demoId in the url cannot find an annotated argument in the method unmatchedPathParamMethod.",
+            exception.getMessage());
     }
 }


### PR DESCRIPTION
The term "base URL" is common in the industry to describe the . See:
 https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base 

or just search for "base url".

Currently, `cleverclient` uses the terms  `urlBase` and `URL_BASE`. This PR reverses the order of all occurrences to the standard notation.

The PR also includes a few of minor refactoring (recommendations of intelliJ idea) and a typo fix in a comment.

In order to maintain API compatibility for the builder, the urlBase remains in deprecated mode. So, you can build a CleverClient with either `.baseUrl()` or `.urlBase()`. Internally, only the baseUrl field is used.

Note that there is a slight API breakage here if you try to build CleverClient directly using its public constructor, because now the constructor has an extra parameter. I think this is reasonable.

